### PR TITLE
feat(ui): responsive 16:9 desktop layout (Closes #89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ Categories (omit a category if it has no entries):
   ### Internal
 -->
 
+### Features
+- Responsive desktop layout. Viewports `>= 960px` wide unfold a 16:9
+  dashboard with a vertical tab rail on the left, the active screen in
+  the center, and a live status rail on the right (credits, day, station
+  summary, ship hull / fuel / cargo). Viewports `< 960px` keep the
+  portrait stack unchanged. The break is viewport-driven, not user-agent
+  driven. Electron windows now open at 1280x720 with a 960x540 minimum,
+  and the PWA manifest no longer locks orientation to portrait. (#89)
+
 ### Improvements
 - Save files now carry a version envelope (`{ v, state }`) and migrate
   forward automatically on load. Legacy saves written by v0.1.x are detected

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -8,10 +8,11 @@ const path = require('path');
 
 function createWindow() {
   const win = new BrowserWindow({
-    width: 480,
-    height: 900,
-    minWidth: 360,
-    minHeight: 600,
+    width: 1280,
+    height: 720,
+    minWidth: 960,
+    minHeight: 540,
+    resizable: true,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -5,7 +5,7 @@
   "start_url": "./",
   "scope": "./",
   "display": "standalone",
-  "orientation": "portrait",
+  "orientation": "any",
   "background_color": "#05070d",
   "theme_color": "#05070d",
   "categories": ["games", "entertainment", "strategy"],

--- a/src/data/changelog.generated.json
+++ b/src/data/changelog.generated.json
@@ -1,8 +1,8 @@
 {
   "currentVersion": "0.2.0-dev.0",
-  "build": 2,
+  "build": 21,
   "channel": "development",
-  "generatedAt": "2026-05-02T19:12:20.113Z",
+  "generatedAt": "2026-05-02T19:44:43.621Z",
   "releases": [
     {
       "version": "Unreleased",
@@ -11,6 +11,13 @@
       "title": "",
       "description": "",
       "categories": [
+        {
+          "id": "features",
+          "label": "New",
+          "entries": [
+            "Responsive desktop layout. Viewports `>= 960px` wide unfold a 16:9 dashboard with a vertical tab rail on the left, the active screen in the center, and a live status rail on the right (credits, day, station summary, ship hull / fuel / cargo). Viewports `< 960px` keep the portrait stack unchanged. The break is viewport-driven, not user-agent driven. Electron windows now open at 1280x720 with a 960x540 minimum, and the PWA manifest no longer locks orientation to portrait. (#89)"
+          ]
+        },
         {
           "id": "improvements",
           "label": "Improvements",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,11 +1,15 @@
 /*
- * Stellar Reach UI — sci-fi datapad, mobile portrait.
+ * Stellar Reach UI — sci-fi datapad.
  *
  * Design rules:
  *  - Dark background, neon accents (cyan, violet, amber).
  *  - Monospace digits where numbers matter.
- *  - All interactive elements >= 44px tall (mobile tap targets).
- *  - Layout assumes a portrait viewport up to 600px wide.
+ *  - All interactive elements >= 44px tall on touch viewports.
+ *  - Mobile-first: default rules below 960px assume portrait; the desktop
+ *    media query at the bottom of this file unfolds a 3-column dashboard
+ *    on viewports >= 960px wide. The break is viewport-driven, not
+ *    user-agent driven, so a desktop browser at any size and a phone in
+ *    landscape both pick the right layout automatically.
  */
 
 :root {
@@ -114,6 +118,16 @@ select {
   background: linear-gradient(180deg, #07101f 0%, #050810 100%);
   border-left: 1px solid var(--line);
   border-right: 1px solid var(--line);
+}
+
+/* The right rail is desktop-only; CSS reveals it inside the media query. */
+.rightrail {
+  display: none;
+}
+
+.rightrail-name {
+  font-size: 15px;
+  letter-spacing: 0.04em;
 }
 
 .topbar {
@@ -694,3 +708,137 @@ select {
   font-size: 13px;
   color: var(--fg-0);
 }
+
+/* ---------------------------------------------------------------------- */
+/* Desktop / wide-viewport layout (>= 960px).                              */
+/*                                                                         */
+/* The .app element is reshaped into a 3-column grid:                      */
+/*   left  : vertical TabBar rail                                          */
+/*   main  : active screen                                                 */
+/*   right : RightRail status summary                                      */
+/*                                                                         */
+/* TopBar spans all three columns at the top. The mobile bottom-bar        */
+/* TabBar styling is replaced with a vertical chip rail. The .rightrail    */
+/* aside becomes visible. The 600px max-width constraint is lifted.        */
+/* ---------------------------------------------------------------------- */
+@media (min-width: 960px) {
+  html,
+  body,
+  #root {
+    /* Wide viewports get a slightly larger base size for legibility. */
+    font-size: 16px;
+  }
+
+  .app {
+    display: grid;
+    grid-template-columns: 200px minmax(0, 1fr) 280px;
+    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-areas:
+      'top top top'
+      'tabs main rail';
+    max-width: none;
+    border-left: none;
+    border-right: none;
+    column-gap: 0;
+  }
+
+  .topbar {
+    grid-area: top;
+  }
+
+  /* On desktop the TopBar's station/credits are duplicated in the right
+   * rail; hide the wide central station block to keep the header lean.
+   * The credits + day stay in the TopBar so they remain glanceable from
+   * the main column without scanning right.
+   */
+  .topbar .station {
+    display: none;
+  }
+
+  .screen {
+    grid-area: main;
+    padding: 18px 20px 24px;
+  }
+
+  /* Vertical tab rail. Reset the mobile fixed-bottom positioning. */
+  .tabbar {
+    grid-area: tabs;
+    position: static;
+    inset: auto;
+    margin: 0;
+    max-width: none;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
+    padding: 12px 8px;
+    border-top: none;
+    border-right: 1px solid var(--line);
+    background: rgba(5, 8, 16, 0.85);
+  }
+
+  .tabbar button {
+    text-align: left;
+    padding: 12px 12px;
+    font-size: 12px;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+  }
+
+  .tabbar button.active {
+    border-color: rgba(34, 211, 238, 0.35);
+  }
+
+  .rightrail {
+    grid-area: rail;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 18px 14px 24px;
+    border-left: 1px solid var(--line);
+    background: rgba(5, 8, 16, 0.6);
+    overflow-y: auto;
+  }
+
+  .rightrail .card {
+    margin-bottom: 0;
+  }
+
+  /* The starmap is intrinsically square; cap it on desktop so it doesn't
+   * push the rest of the Helm content offscreen on widescreen viewports.
+   */
+  .starmap {
+    max-width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  /* Modals slot into the dashboard rather than sliding from the bottom.
+   * They still center the content but use a desktop-shaped panel.
+   */
+  .modal {
+    margin: auto;
+    max-width: 640px;
+    border-top: 1px solid var(--accent-cyan);
+    border-radius: var(--radius-md);
+    max-height: 80vh;
+  }
+}
+
+@media (min-width: 1280px) {
+  .app {
+    grid-template-columns: 220px minmax(0, 1fr) 320px;
+  }
+
+  .screen {
+    padding: 22px 28px 28px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -11,6 +11,7 @@ import { LogScreen } from './screens/LogScreen';
 import { TripModal } from './components/TripModal';
 import { TopBar } from './components/TopBar';
 import { TabBar } from './components/TabBar';
+import { RightRail } from './components/RightRail';
 
 const SCREEN_LABELS: { id: Screen; label: string }[] = [
   { id: 'market', label: 'Market' },
@@ -36,9 +37,15 @@ export function App() {
   if (!hydrated) return null;
   if (!game) return <TitleScreen />;
 
+  // The single CSS architecture lives in global.css and uses a min-width
+  // media query at 960px. On mobile the .app element is a portrait column.
+  // On desktop it becomes a 3-column grid: left rail (vertical tabs), main
+  // column, and right rail (status summary). Both layouts render the same
+  // markup; CSS picks where each child sits.
   return (
     <div className="app">
       <TopBar />
+      <TabBar tabs={SCREEN_LABELS} />
       <main className="screen">
         {screen === 'market' && <MarketScreen />}
         {screen === 'ship' && <ShipScreen />}
@@ -48,7 +55,7 @@ export function App() {
         {screen === 'missions' && <MissionsScreen />}
         {screen === 'log' && <LogScreen />}
       </main>
-      <TabBar tabs={SCREEN_LABELS} />
+      <RightRail />
       {trip && <TripModal />}
     </div>
   );

--- a/src/ui/components/RightRail.tsx
+++ b/src/ui/components/RightRail.tsx
@@ -49,21 +49,45 @@ export function RightRail() {
           <span className="k">Hull</span>
           <span className="v">{ship.hull}/{ship.hullMax}</span>
         </div>
-        <div className="bar" aria-label={`Hull ${hullPct}%`}>
+        <div
+          className="bar"
+          role="progressbar"
+          aria-label="Hull"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={hullPct}
+          aria-valuetext={`${ship.hull} of ${ship.hullMax}`}
+        >
           <div style={{ width: `${hullPct}%` }} />
         </div>
         <div className="kv" style={{ marginTop: 6 }}>
           <span className="k">Fuel</span>
           <span className="v">{ship.fuel}/{ship.fuelMax}</span>
         </div>
-        <div className="bar" aria-label={`Fuel ${fuelPct}%`}>
+        <div
+          className="bar"
+          role="progressbar"
+          aria-label="Fuel"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={fuelPct}
+          aria-valuetext={`${ship.fuel} of ${ship.fuelMax}`}
+        >
           <div style={{ width: `${fuelPct}%` }} />
         </div>
         <div className="kv" style={{ marginTop: 6 }}>
           <span className="k">Cargo</span>
           <span className="v">{ship.cargo}/{ship.cargoMax}</span>
         </div>
-        <div className="bar" aria-label={`Cargo ${cargoPct}%`}>
+        <div
+          className="bar"
+          role="progressbar"
+          aria-label="Cargo"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={cargoPct}
+          aria-valuetext={`${ship.cargo} of ${ship.cargoMax}`}
+        >
           <div style={{ width: `${cargoPct}%` }} />
         </div>
       </div>

--- a/src/ui/components/RightRail.tsx
+++ b/src/ui/components/RightRail.tsx
@@ -1,0 +1,72 @@
+import { useGameStore } from '../../state/store';
+import { currentStation, currentSystem } from '../../engine/game';
+import { RACES_BY_ID } from '../../data/races';
+
+/**
+ * Right-rail summary panel rendered on desktop layouts (>= 960px viewports).
+ * Shows the same vital signs that the TopBar shows on mobile, in a denser
+ * stacked form. The TopBar hides this content on desktop so the data is not
+ * duplicated.
+ */
+export function RightRail() {
+  const game = useGameStore((s) => s.game);
+  if (!game) return null;
+  const station = currentStation(game);
+  const system = currentSystem(game);
+  const race = station ? RACES_BY_ID[station.raceId] : undefined;
+  const ship = game.player.ship;
+
+  const hullPct = ship.hullMax > 0 ? Math.round((ship.hull / ship.hullMax) * 100) : 0;
+  const fuelPct = ship.fuelMax > 0 ? Math.round((ship.fuel / ship.fuelMax) * 100) : 0;
+  const cargoPct = ship.cargoMax > 0 ? Math.round((ship.cargo / ship.cargoMax) * 100) : 0;
+
+  return (
+    <aside className="rightrail" aria-label="Status summary">
+      <div className="card">
+        <h3>Status</h3>
+        <div className="kv">
+          <span className="k">Day</span>
+          <span className="v">{String(game.player.day).padStart(3, '0')}</span>
+          <span className="k">Credits</span>
+          <span className="v amber">{game.player.credits.toLocaleString()}</span>
+        </div>
+      </div>
+
+      <div className="card">
+        <h3>Station</h3>
+        <div className="rightrail-name cyan">{station?.name ?? 'Unknown'}</div>
+        <div className="tiny" style={{ marginTop: 2 }}>
+          {system?.name} | {system?.region}
+        </div>
+        <div className="tiny" style={{ marginTop: 2 }}>
+          {station?.kind} | {race?.adjective}
+        </div>
+      </div>
+
+      <div className="card">
+        <h3>Ship</h3>
+        <div className="kv">
+          <span className="k">Hull</span>
+          <span className="v">{ship.hull}/{ship.hullMax}</span>
+        </div>
+        <div className="bar" aria-label={`Hull ${hullPct}%`}>
+          <div style={{ width: `${hullPct}%` }} />
+        </div>
+        <div className="kv" style={{ marginTop: 6 }}>
+          <span className="k">Fuel</span>
+          <span className="v">{ship.fuel}/{ship.fuelMax}</span>
+        </div>
+        <div className="bar" aria-label={`Fuel ${fuelPct}%`}>
+          <div style={{ width: `${fuelPct}%` }} />
+        </div>
+        <div className="kv" style={{ marginTop: 6 }}>
+          <span className="k">Cargo</span>
+          <span className="v">{ship.cargo}/{ship.cargoMax}</span>
+        </div>
+        <div className="bar" aria-label={`Cargo ${cargoPct}%`}>
+          <div style={{ width: `${cargoPct}%` }} />
+        </div>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
Closes #89

## Summary

Viewports `>= 960px` wide unfold a 3-column dashboard: vertical tab rail on
the left, active screen in the center, and a live status rail on the right.
Viewports `< 960px` keep the existing portrait stack unchanged. The break
is viewport-driven via a single `min-width: 960px` media query, not
user-agent sniffing — desktop browsers and phones in landscape both pick
the right layout automatically.

## Changes

- New `src/ui/components/RightRail.tsx` showing credits, day, station
  name + system + race + kind, and ship hull / fuel / cargo bars. Hidden
  below 960px via CSS, revealed inside the desktop media query.
- `src/ui/App.tsx` layout shell now renders `TopBar`, `TabBar`, `<main>`,
  `RightRail` as siblings of `.app`. CSS picks the layout.
- `.app` becomes a CSS grid at `>= 960px` with a second tier at
  `>= 1280px` for slightly wider rails. The 600px max-width constraint
  is lifted on desktop.
- `TabBar` becomes a vertical chip rail on desktop; bottom bar on mobile.
- `TopBar` hides its central station block on desktop because the right
  rail carries the same data — no duplication.
- `electron/main.cjs`: window defaults to 1280x720, minimum 960x540,
  resizable.
- `public/manifest.webmanifest`: `orientation` set to `"any"`.
- Global `prefers-reduced-motion: reduce` short-circuits transitions and
  animations.

## Verification

Tested by resizing the dev build between 360 / 600 / 960 / 1280 / 1920px
viewports. Tab targets remain `>= 44px` on both layouts. `npm run typecheck`,
`npm run lint`, and `npm run build` all green.

## Out of scope

Visual restyle (#90) and galaxy map renderer (#91) are tracked separately.
