### PR TITLE
feat(ui): datapad-style visual redesign (Closes #90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ Categories (omit a category if it has no entries):
   and the PWA manifest no longer locks orientation to portrait. (#89)
 
 ### Improvements
+- Datapad visual restyle. Sharp-cornered panels replace the previous
+  rounded look. Two accent colours dominate: muted neon green
+  (`#7BD389`) for confirm / active / nominal states, muted red
+  (`#E5484D`) for warnings / close / critical. Cyan, violet, and amber
+  are demoted to secondary accents. New `PanelHeader` component renders
+  a monospace tag like `MARKET / FN03` with a thin status strip on every
+  gameplay screen. Numeric readouts use a monospace face; labels use
+  small uppercase tracked sans. Decorative diagonal-stripe accents anchor
+  the four corners of the app shell. Reduced-motion preference respected.
+  (#90)
 - Save files now carry a version envelope (`{ v, state }`) and migrate
   forward automatically on load. Legacy saves written by v0.1.x are detected
   by the old key and migrated seamlessly — no save lost on upgrade. (#21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ Categories (omit a category if it has no entries):
   by the old key and migrated seamlessly — no save lost on upgrade. (#21)
 
 ### Bug Fixes
+- Datapad redesign accessibility/layout fixes: corner-accent stripes now
+  anchor to the `.app` shell (added `position: relative`) instead of
+  drifting to the viewport corners on tablet-width layouts; `PanelHeader`
+  renders a real heading element (default `<h2>`, optional `as="h3"`)
+  so screen-reader heading navigation continues to land on each panel
+  title. (#90)
 - Replaced `Math.random()` bootstrap calls in `src/engine/rng.ts` and
   `src/engine/game.ts` with `crypto.getRandomValues()`, satisfying the
   determinism policy. The UI and engine no longer call `Math.random`

--- a/src/data/changelog.generated.json
+++ b/src/data/changelog.generated.json
@@ -1,8 +1,8 @@
 {
   "currentVersion": "0.2.0-dev.0",
-  "build": 21,
+  "build": 22,
   "channel": "development",
-  "generatedAt": "2026-05-02T19:44:43.621Z",
+  "generatedAt": "2026-05-02T19:49:53.019Z",
   "releases": [
     {
       "version": "Unreleased",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -158,6 +158,11 @@ select:focus-visible {
 }
 
 .app {
+  /* Establishes the containing block for the absolutely-positioned
+   * .corner-accent children below, so the accents anchor to the app
+   * shell instead of the viewport on layouts where the shell is
+   * narrower than the screen (e.g. tablet 1024–1280px). */
+  position: relative;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -365,6 +370,7 @@ select:focus-visible {
   padding: 0;
   font-family: var(--font-mono);
   font-size: 11px;
+  font-weight: inherit;
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--fg-1);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,25 +13,51 @@
  */
 
 :root {
-  --bg-0: #05070d;
-  --bg-1: #0a1020;
-  --bg-2: #111a2e;
-  --bg-3: #182542;
-  --line: #1f2c4d;
-  --line-2: #2a3a66;
+  /* Datapad palette (issue #90).
+   *
+   * Background is pure dark. Two accent colours dominate:
+   *   --accent-ok    : muted neon green for confirm / active / nominal.
+   *   --accent-alert : muted red for warnings / close / critical.
+   * Cyan, violet, amber, rose remain available as secondary accents only.
+   *
+   * Contrast notes (vs --bg-0 #05070d):
+   *   #7BD389 contrast ~10.5 (AAA for body text)
+   *   #E5484D contrast ~4.7  (AA for normal text)
+   */
+  --bg-0: #04060a;
+  --bg-1: #080c14;
+  --bg-2: #0d121d;
+  --bg-3: #131a28;
+  --line: #1c2538;
+  --line-2: #2a3650;
   --fg-0: #e6ecff;
   --fg-1: #b8c1e0;
-  --fg-2: #7787b3;
+  --fg-2: #6b7896;
+
+  /* Primary accents. */
+  --accent-ok: #7bd389;
+  --accent-alert: #e5484d;
+
+  /* Secondary accents (used sparingly for trend / category markers). */
   --accent-cyan: #22d3ee;
   --accent-violet: #a78bfa;
   --accent-amber: #fbbf24;
   --accent-rose: #f472b6;
-  --accent-green: #4ade80;
-  --accent-red: #f87171;
-  --radius-sm: 6px;
-  --radius-md: 10px;
-  --radius-lg: 16px;
-  --shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+  --accent-green: var(--accent-ok);
+  --accent-red: var(--accent-alert);
+
+  /* Sharp panels: only chips and inputs keep a small radius. */
+  --radius-sm: 4px;
+  --radius-md: 0px;
+  --radius-lg: 0px;
+
+  --shadow: 0 6px 18px rgba(0, 0, 0, 0.5);
+
+  /* Typography helpers. */
+  --label-tracking: 0.12em;
+  --font-mono: ui-monospace, 'JetBrains Mono', 'SFMono-Regular', Menlo, Consolas, monospace;
+  --font-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-serif: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
 
   color-scheme: dark;
 }
@@ -60,53 +86,75 @@ button {
   color: inherit;
   background: transparent;
   border: 1px solid var(--line-2);
-  border-radius: var(--radius-md);
+  border-radius: 0;
   padding: 10px 14px;
   cursor: pointer;
   min-height: 44px;
-  letter-spacing: 0.02em;
-  transition: background-color 120ms ease, border-color 120ms ease, transform 80ms ease;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 12px;
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
 }
 
 button:hover:not(:disabled) {
   background: var(--bg-2);
-  border-color: var(--accent-cyan);
+  border-color: var(--accent-ok);
+  color: var(--accent-ok);
 }
 
 button:active:not(:disabled) {
-  transform: scale(0.98);
+  background: var(--bg-3);
+}
+
+button:focus-visible {
+  outline: 2px solid var(--accent-amber);
+  outline-offset: 2px;
 }
 
 button:disabled {
-  opacity: 0.45;
+  opacity: 0.4;
   cursor: not-allowed;
 }
 
 button.primary {
-  background: linear-gradient(180deg, #103a52 0%, #0a2335 100%);
-  border-color: var(--accent-cyan);
-  color: var(--accent-cyan);
+  background: linear-gradient(180deg, rgba(123, 211, 137, 0.12) 0%, rgba(123, 211, 137, 0.04) 100%);
+  border-color: var(--accent-ok);
+  color: var(--accent-ok);
+}
+
+button.primary:hover:not(:disabled) {
+  background: rgba(123, 211, 137, 0.18);
 }
 
 button.danger {
-  border-color: var(--accent-red);
-  color: var(--accent-red);
+  border-color: var(--accent-alert);
+  color: var(--accent-alert);
+  background: rgba(229, 72, 77, 0.06);
 }
 
 button.muted {
   border-color: var(--line);
   color: var(--fg-1);
+  background: var(--bg-1);
 }
 
 input,
 select {
   font: inherit;
+  font-family: var(--font-mono);
   color: var(--fg-0);
   background: var(--bg-1);
   border: 1px solid var(--line-2);
   border-radius: var(--radius-sm);
   padding: 8px 10px;
   min-height: 40px;
+}
+
+input:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--accent-amber);
+  outline-offset: 1px;
+  border-color: var(--accent-ok);
 }
 
 .app {
@@ -128,6 +176,68 @@ select {
 .rightrail-name {
   font-size: 15px;
   letter-spacing: 0.04em;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+}
+
+/* Decorative diagonal-stripe accents anchored to the four corners of the
+ * .app shell. Pure CSS, pointer-events: none, hidden behind content. The
+ * stripes use the muted-green accent for top corners and muted-red for
+ * bottom corners to read as nominal/critical edges of the datapad frame.
+ */
+.corner-accent {
+  position: absolute;
+  width: 96px;
+  height: 96px;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.55;
+  background-image: repeating-linear-gradient(
+    135deg,
+    transparent 0,
+    transparent 6px,
+    rgba(123, 211, 137, 0.4) 6px,
+    rgba(123, 211, 137, 0.4) 8px
+  );
+}
+
+.corner-tl {
+  top: 0;
+  left: 0;
+  -webkit-mask-image: linear-gradient(135deg, #000 0%, transparent 70%);
+  mask-image: linear-gradient(135deg, #000 0%, transparent 70%);
+}
+
+.corner-tr {
+  top: 0;
+  right: 0;
+  -webkit-mask-image: linear-gradient(225deg, #000 0%, transparent 70%);
+  mask-image: linear-gradient(225deg, #000 0%, transparent 70%);
+}
+
+.corner-bl,
+.corner-br {
+  background-image: repeating-linear-gradient(
+    135deg,
+    transparent 0,
+    transparent 6px,
+    rgba(229, 72, 77, 0.32) 6px,
+    rgba(229, 72, 77, 0.32) 8px
+  );
+}
+
+.corner-bl {
+  bottom: 0;
+  left: 0;
+  -webkit-mask-image: linear-gradient(45deg, #000 0%, transparent 70%);
+  mask-image: linear-gradient(45deg, #000 0%, transparent 70%);
+}
+
+.corner-br {
+  bottom: 0;
+  right: 0;
+  -webkit-mask-image: linear-gradient(315deg, #000 0%, transparent 70%);
+  mask-image: linear-gradient(315deg, #000 0%, transparent 70%);
 }
 
 .topbar {
@@ -138,8 +248,10 @@ select {
   padding: env(safe-area-inset-top) 12px 8px;
   padding-top: max(env(safe-area-inset-top), 8px);
   border-bottom: 1px solid var(--line);
-  background: rgba(5, 8, 16, 0.95);
+  background: rgba(4, 6, 10, 0.95);
   backdrop-filter: blur(6px);
+  position: relative;
+  z-index: 2;
 }
 
 .topbar .station {
@@ -149,34 +261,40 @@ select {
 }
 
 .topbar .station .name {
-  color: var(--accent-cyan);
-  letter-spacing: 0.04em;
+  color: var(--fg-0);
+  letter-spacing: 0.06em;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
 }
 
 .topbar .station .sub {
   color: var(--fg-2);
-  font-size: 12px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .topbar .credits {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  color: var(--accent-amber);
+  font-family: var(--font-mono);
+  color: var(--fg-0);
   font-size: 16px;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
   text-align: right;
 }
 
 .topbar .credits .label {
   color: var(--fg-2);
-  font-size: 11px;
-  letter-spacing: 0.12em;
+  font-size: 10px;
+  letter-spacing: var(--label-tracking);
   display: block;
+  text-transform: uppercase;
 }
 
 .topbar .day {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  color: var(--accent-violet);
-  font-size: 14px;
+  font-family: var(--font-mono);
+  color: var(--accent-ok);
+  font-size: 13px;
+  letter-spacing: 0.08em;
 }
 
 .screen {
@@ -190,47 +308,108 @@ select {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
   border-top: 1px solid var(--line);
-  background: rgba(5, 8, 16, 0.97);
+  background: rgba(4, 6, 10, 0.97);
   padding: 6px 4px max(8px, env(safe-area-inset-bottom));
   position: absolute;
   inset: auto 0 0 0;
   max-width: 600px;
   margin: 0 auto;
+  gap: 4px;
 }
 
 .tabbar button {
-  border: none;
+  border: 1px solid transparent;
   background: transparent;
   color: var(--fg-2);
   padding: 8px 4px;
   min-height: 44px;
   font-size: 11px;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  border-radius: var(--radius-sm);
+  border-radius: 0;
 }
 
 .tabbar button.active {
-  color: var(--accent-cyan);
-  background: rgba(34, 211, 238, 0.08);
+  color: var(--accent-ok);
+  background: rgba(123, 211, 137, 0.08);
+  border-color: rgba(123, 211, 137, 0.35);
 }
 
 .card {
   background: var(--bg-1);
   border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  padding: 12px;
+  border-radius: 0;
+  padding: 14px 14px 12px;
   box-shadow: var(--shadow);
   margin-bottom: 12px;
+  position: relative;
 }
 
 .card h2,
 .card h3 {
   margin: 0 0 8px 0;
-  font-size: 14px;
-  letter-spacing: 0.12em;
+  font-size: 11px;
+  letter-spacing: var(--label-tracking);
   text-transform: uppercase;
-  color: var(--accent-violet);
+  color: var(--fg-1);
+  font-weight: 600;
+}
+
+/* Datapad panel header (PanelHeader component). ----------------------- */
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: -2px 0 10px;
+  padding: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-1);
+}
+
+.panel-header-strip {
+  display: inline-block;
+  width: 3px;
+  height: 14px;
+  background: var(--accent-ok);
+}
+
+.panel-header[data-status='warn'] .panel-header-strip {
+  background: var(--accent-amber);
+}
+
+.panel-header[data-status='alert'] .panel-header-strip {
+  background: var(--accent-alert);
+}
+
+.panel-header-label {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  flex: 1;
+}
+
+.panel-header-tag {
+  color: var(--fg-0);
+}
+
+.panel-header-sep {
+  color: var(--fg-2);
+}
+
+.panel-header-code {
+  color: var(--fg-2);
+}
+
+.panel-header-right {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--fg-2);
+  text-transform: uppercase;
 }
 
 .row {
@@ -357,10 +536,11 @@ select {
 }
 
 .market-row .price {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  color: var(--accent-amber);
+  font-family: var(--font-mono);
+  color: var(--fg-0);
   text-align: right;
   font-size: 16px;
+  letter-spacing: 0.04em;
 }
 
 .market-row .controls {
@@ -381,11 +561,11 @@ select {
   width: 100%;
   aspect-ratio: 1 / 1;
   background:
-    radial-gradient(circle at 30% 30%, rgba(167, 139, 250, 0.08), transparent 60%),
-    radial-gradient(circle at 70% 70%, rgba(34, 211, 238, 0.08), transparent 55%),
+    radial-gradient(circle at 30% 30%, rgba(123, 211, 137, 0.06), transparent 60%),
+    radial-gradient(circle at 70% 70%, rgba(34, 211, 238, 0.06), transparent 55%),
     var(--bg-1);
   border: 1px solid var(--line);
-  border-radius: var(--radius-md);
+  border-radius: 0;
   overflow: hidden;
 }
 
@@ -422,12 +602,13 @@ select {
   max-width: 600px;
   margin-top: auto;
   background: var(--bg-1);
-  border-top: 1px solid var(--accent-cyan);
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  border: 1px solid var(--line-2);
+  border-top: 2px solid var(--accent-ok);
+  border-radius: 0;
   padding: 16px 14px max(16px, env(safe-area-inset-bottom));
   max-height: 85vh;
   overflow-y: auto;
-  box-shadow: 0 -10px 40px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 -10px 40px rgba(0, 0, 0, 0.6);
 }
 
 .title-screen {
@@ -444,8 +625,9 @@ select {
   font-size: 36px;
   letter-spacing: 0.3em;
   margin: 0;
-  color: var(--accent-cyan);
-  text-shadow: 0 0 24px rgba(34, 211, 238, 0.4);
+  color: var(--accent-ok);
+  text-shadow: 0 0 20px rgba(123, 211, 137, 0.35);
+  font-family: var(--font-mono);
 }
 
 .title-screen .sub {
@@ -453,6 +635,7 @@ select {
   letter-spacing: 0.2em;
   text-transform: uppercase;
   font-size: 12px;
+  font-family: var(--font-mono);
 }
 
 .title-screen .actions {
@@ -467,7 +650,7 @@ select {
 .choice-card {
   background: var(--bg-2);
   border: 1px solid var(--line-2);
-  border-radius: var(--radius-md);
+  border-radius: 0;
   padding: 12px;
   margin-bottom: 10px;
 }
@@ -564,11 +747,11 @@ select {
 }
 
 .notice {
-  background: rgba(34, 211, 238, 0.08);
-  border: 1px solid rgba(34, 211, 238, 0.4);
+  background: rgba(123, 211, 137, 0.08);
+  border: 1px solid rgba(123, 211, 137, 0.4);
   color: var(--fg-0);
   padding: 10px 12px;
-  border-radius: var(--radius-sm);
+  border-radius: 0;
   font-size: 13px;
 }
 
@@ -578,8 +761,8 @@ select {
 }
 
 .notice.bad {
-  background: rgba(248, 113, 113, 0.08);
-  border-color: rgba(248, 113, 113, 0.6);
+  background: rgba(229, 72, 77, 0.08);
+  border-color: rgba(229, 72, 77, 0.6);
 }
 
 /* Changelog viewer (title screen + version chip) ------------------------- */

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -44,6 +44,10 @@ export function App() {
   // markup; CSS picks where each child sits.
   return (
     <div className="app">
+      <div className="corner-accent corner-tl" aria-hidden="true" />
+      <div className="corner-accent corner-tr" aria-hidden="true" />
+      <div className="corner-accent corner-bl" aria-hidden="true" />
+      <div className="corner-accent corner-br" aria-hidden="true" />
       <TopBar />
       <TabBar tabs={SCREEN_LABELS} />
       <main className="screen">

--- a/src/ui/components/PanelHeader.tsx
+++ b/src/ui/components/PanelHeader.tsx
@@ -1,0 +1,32 @@
+interface Props {
+  /** Short uppercase identifier shown left of the slash, e.g. "MARKET". */
+  tag: string;
+  /** Function code shown right of the slash, e.g. "FN03". */
+  code: string;
+  /**
+   * Status strip colour. 'ok' is muted neon green (nominal),
+   * 'warn' is amber (caution), 'alert' is muted red (critical).
+   */
+  status?: 'ok' | 'warn' | 'alert';
+  /** Optional right-aligned text, e.g. a live count or rate. */
+  rightSlot?: React.ReactNode;
+}
+
+/**
+ * Datapad-style panel header. Renders a small monospace tag like
+ * `MARKET / FN03` paired with a thin status strip, matching the
+ * in-universe ship console UI direction.
+ */
+export function PanelHeader({ tag, code, status = 'ok', rightSlot }: Props) {
+  return (
+    <div className="panel-header" data-status={status}>
+      <span className="panel-header-strip" aria-hidden="true" />
+      <span className="panel-header-label">
+        <span className="panel-header-tag">{tag}</span>
+        <span className="panel-header-sep">/</span>
+        <span className="panel-header-code">{code}</span>
+      </span>
+      {rightSlot ? <span className="panel-header-right">{rightSlot}</span> : null}
+    </div>
+  );
+}

--- a/src/ui/components/PanelHeader.tsx
+++ b/src/ui/components/PanelHeader.tsx
@@ -10,16 +10,25 @@ interface Props {
   status?: 'ok' | 'warn' | 'alert';
   /** Optional right-aligned text, e.g. a live count or rate. */
   rightSlot?: React.ReactNode;
+  /**
+   * Heading level. Each screen is one logical section, so panels
+   * default to `h2`. Pass `h3` for nested panels inside a screen that
+   * already owns its own `h2`.
+   */
+  as?: 'h2' | 'h3';
 }
 
 /**
  * Datapad-style panel header. Renders a small monospace tag like
  * `MARKET / FN03` paired with a thin status strip, matching the
- * in-universe ship console UI direction.
+ * in-universe ship console UI direction. The outer element is a real
+ * heading (default `h2`) so screen-reader heading navigation continues
+ * to land on each panel title.
  */
-export function PanelHeader({ tag, code, status = 'ok', rightSlot }: Props) {
+export function PanelHeader({ tag, code, status = 'ok', rightSlot, as = 'h2' }: Props) {
+  const Heading = as;
   return (
-    <div className="panel-header" data-status={status}>
+    <Heading className="panel-header" data-status={status}>
       <span className="panel-header-strip" aria-hidden="true" />
       <span className="panel-header-label">
         <span className="panel-header-tag">{tag}</span>
@@ -27,6 +36,6 @@ export function PanelHeader({ tag, code, status = 'ok', rightSlot }: Props) {
         <span className="panel-header-code">{code}</span>
       </span>
       {rightSlot ? <span className="panel-header-right">{rightSlot}</span> : null}
-    </div>
+    </Heading>
   );
 }

--- a/src/ui/screens/CrewScreen.tsx
+++ b/src/ui/screens/CrewScreen.tsx
@@ -2,6 +2,7 @@ import { useGameStore } from '../../state/store';
 import { CREW_TRAITS_BY_ID } from '../../data/traits';
 import { RACES_BY_ID } from '../../data/races';
 import type { CrewMember } from '../../engine/types';
+import { PanelHeader } from '../components/PanelHeader';
 
 function CrewRow({ member, action, actionLabel, actionDisabled, secondary, secondaryLabel }: {
   member: CrewMember;
@@ -60,7 +61,12 @@ export function CrewScreen() {
   return (
     <div>
       <div className="card">
-        <h3>Active Crew ({game.player.crew.length}/8)</h3>
+        <PanelHeader
+          tag="CREW"
+          code="FN02"
+          status="ok"
+          rightSlot={`${game.player.crew.length}/8 ACTIVE`}
+        />
         {game.player.crew.length === 0 && <div className="muted">You fly alone.</div>}
         {game.player.crew.map((m) => (
           <CrewRow
@@ -75,7 +81,7 @@ export function CrewScreen() {
       </div>
 
       <div className="card">
-        <h3>Hire Roster — Local Spaceport</h3>
+        <PanelHeader tag="ROSTER" code="FN02B" status="ok" rightSlot="LOCAL PORT" />
         {game.hireRoster.length === 0 && <div className="muted">No-one is looking for a berth here.</div>}
         {game.hireRoster.map((m) => {
           const fee = m.wage * 5;

--- a/src/ui/screens/HelmScreen.tsx
+++ b/src/ui/screens/HelmScreen.tsx
@@ -4,6 +4,7 @@ import { allStations, currentStation, currentSystem } from '../../engine/game';
 import { estimateRoute } from '../../engine/game';
 import { RACES_BY_ID } from '../../data/races';
 import { GOODS_BY_ID } from '../../data/goods';
+import { PanelHeader } from '../components/PanelHeader';
 
 type SafetyChoice = 'safe' | 'fast';
 
@@ -65,7 +66,7 @@ export function HelmScreen() {
   return (
     <div>
       <div className="card">
-        <h3>Star Map</h3>
+        <PanelHeader tag="STARMAP" code="FN04" status="ok" rightSlot={`${game.galaxy.systems.length} SYS`} />
         <div className="starmap">
           <svg viewBox="0 0 1000 1000">
             {game.galaxy.systems.map((sys) => {
@@ -104,7 +105,7 @@ export function HelmScreen() {
       </div>
 
       <div className="card">
-        <h3>Destinations</h3>
+        <PanelHeader tag="DESTINATIONS" code="FN04A" status="ok" />
         <div className="list">
           {stations.map((s) => {
             const sys = game.galaxy.systems.find((y) => y.stations.some((st) => st.id === s.id));
@@ -131,7 +132,7 @@ export function HelmScreen() {
 
       {target && route && (
         <div className="card">
-          <h3>Plot Course</h3>
+          <PanelHeader tag="PLOT" code="FN04B" status={canTravel ? 'ok' : 'warn'} />
           <div className="row" style={{ marginBottom: 8 }}>
             <button className={`chip ${safety === 'safe' ? 'active' : ''}`} onClick={() => setSafety('safe')}>
               Safe Route

--- a/src/ui/screens/LogScreen.tsx
+++ b/src/ui/screens/LogScreen.tsx
@@ -1,4 +1,5 @@
 import { useGameStore } from '../../state/store';
+import { PanelHeader } from '../components/PanelHeader';
 
 export function LogScreen() {
   const game = useGameStore((s) => s.game)!;
@@ -8,7 +9,7 @@ export function LogScreen() {
   return (
     <div>
       <div className="card">
-        <h3>Captain's Log</h3>
+        <PanelHeader tag="LOG" code="FN07" status="ok" rightSlot={`D${String(game.player.day).padStart(3, '0')}`} />
         <div className="tiny">Galaxy seed: <span className="mono cyan">{game.galaxy.seed}</span></div>
         <div className="tiny">Captain: {game.player.captainName}</div>
         <div className="divider" />
@@ -19,7 +20,7 @@ export function LogScreen() {
         ))}
       </div>
       <div className="card">
-        <h3>Danger Zone</h3>
+        <PanelHeader tag="DANGER" code="FN99" status="alert" />
         <button
           className="danger"
           onClick={() => {

--- a/src/ui/screens/MarketScreen.tsx
+++ b/src/ui/screens/MarketScreen.tsx
@@ -3,6 +3,7 @@ import { useGameStore } from '../../state/store';
 import { currentStation, priceMultipliers } from '../../engine/game';
 import { GOODS_BY_ID } from '../../data/goods';
 import type { GoodCategory } from '../../engine/types';
+import { PanelHeader } from '../components/PanelHeader';
 
 const CATEGORIES: ('All' | GoodCategory)[] = [
   'All',
@@ -48,12 +49,12 @@ export function MarketScreen() {
   return (
     <div>
       <div className="card">
-        <div className="row spread">
-          <h3 style={{ margin: 0 }}>Market</h3>
-          <span className="tiny mono">
-            BUY x{muls.buy.toFixed(2)} / SELL x{muls.sell.toFixed(2)}
-          </span>
-        </div>
+        <PanelHeader
+          tag="MARKET"
+          code="FN03"
+          status="ok"
+          rightSlot={`BUY x${muls.buy.toFixed(2)} / SELL x${muls.sell.toFixed(2)}`}
+        />
         <div className="scroll-x" role="tablist" aria-label="Category filter">
           {CATEGORIES.map((c) => (
             <button

--- a/src/ui/screens/MissionsScreen.tsx
+++ b/src/ui/screens/MissionsScreen.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useGameStore } from '../../state/store';
 import { allStations, currentStation, estimateRoute } from '../../engine/game';
 import { GOODS_BY_ID } from '../../data/goods';
+import { PanelHeader } from '../components/PanelHeader';
 
 export function MissionsScreen() {
   const game = useGameStore((s) => s.game)!;
@@ -25,7 +26,7 @@ export function MissionsScreen() {
   return (
     <div>
       <div className="card">
-        <h3>Hire a Courier</h3>
+        <PanelHeader tag="COURIER" code="FN06" status="ok" />
         <div className="muted" style={{ marginBottom: 8 }}>
           Pay an independent crew to ferry cargo while you stay in port. Their pay is calculated
           against the destination market price; expect ~92% of fair value on delivery.

--- a/src/ui/screens/NewsScreen.tsx
+++ b/src/ui/screens/NewsScreen.tsx
@@ -1,5 +1,6 @@
 import { useGameStore } from '../../state/store';
 import { GOODS_BY_ID } from '../../data/goods';
+import { PanelHeader } from '../components/PanelHeader';
 
 export function NewsScreen() {
   const game = useGameStore((s) => s.game)!;
@@ -8,7 +9,7 @@ export function NewsScreen() {
   return (
     <div>
       <div className="card">
-        <h3>Galactic News Feed</h3>
+        <PanelHeader tag="COMMS" code="FN05" status="ok" rightSlot={`${items.length} ITEMS`} />
         {items.length === 0 && <div className="muted">All quiet across the reach.</div>}
         {items.map((n) => {
           const sys = n.systemId ? game.galaxy.systems.find((s) => s.id === n.systemId) : undefined;

--- a/src/ui/screens/ShipScreen.tsx
+++ b/src/ui/screens/ShipScreen.tsx
@@ -3,6 +3,7 @@ import { SHIP_MODULES, SHIP_MODULES_BY_ID } from '../../data/modules';
 import { GOODS_BY_ID } from '../../data/goods';
 import { currentStation } from '../../engine/game';
 import type { ShipModuleSlot } from '../../engine/types';
+import { PanelHeader } from '../components/PanelHeader';
 
 const SLOTS: ShipModuleSlot[] = ['Hull', 'Cargo', 'Drive', 'Shield', 'Sensor', 'Utility'];
 
@@ -35,7 +36,12 @@ export function ShipScreen() {
   return (
     <div>
       <div className="card">
-        <h3>Vessel: {ship.name}</h3>
+        <PanelHeader
+          tag="VESSEL"
+          code="FN01"
+          status={ship.hull < ship.hullMax * 0.4 ? 'alert' : ship.fuel < ship.fuelMax * 0.25 ? 'warn' : 'ok'}
+          rightSlot={ship.name.toUpperCase()}
+        />
         <div className="kv">
           <span className="k">Hull</span>
           <span className="v">{ship.hull}/{ship.hullMax}</span>


### PR DESCRIPTION
Closes #90

Stacked on top of #92 (issue #89). When that PR merges to development,
this branch will be rebased onto development; the diff here only includes
the visual restyle.

## Summary

Restyles every screen toward the in-universe ship console direction
captured in `galactic-trader/ui-design-reference.jpg`. The previous soft,
rounded look is replaced with sharp-cornered panels and a two-accent
palette.

## Changes

- **`PanelHeader` component** (`src/ui/components/PanelHeader.tsx`)
  renders a small monospace tag like `MARKET / FN03` with a thin
  red / amber / green status strip beside it. Used on Market, Ship,
  Crew, Helm, News, Missions, and Log screens.
- **Two-accent palette.** `--accent-ok` is muted neon green (`#7BD389`,
  contrast ~10.5 on `#04060A`, AAA). `--accent-alert` is muted red
  (`#E5484D`, contrast ~4.7, AA). Cyan, violet, amber, and rose stay
  available as secondary accents only.
- **Sharp corners.** Panel radius dropped to 0; only chips and inputs
  keep `--radius-sm: 4px`.
- **Typography.** Numeric readouts use a monospace face. Labels use a
  small uppercase tracked sans (`letter-spacing: 0.12em`, 11–12px).
- **Corner accents.** Pure-CSS diagonal stripes at the four corners of
  `.app`, masked to fade inward. Top corners use the green accent,
  bottom corners use the red accent. `pointer-events: none`,
  decorative-only.
- **TabBar restyle.** Bottom bar on mobile and left chip rail on
  desktop now share the new tracked uppercase typography and the green
  active state.
- **Modal restyle.** Sharp corners with a thin 2px green top strip.
- **Reduced motion** preference still respected globally.

No emoji. No `Math.random` in renderer or styling code.

## Verification

`npm run typecheck`, `npm run lint`, and `npm run build` all green.
Tested visually at 360 / 600 / 960 / 1280 / 1920px viewports across
every screen.

## Out of scope

Galaxy / system map renderer (#91) is tracked separately.
