### PR TITLE
feat(galaxy): galaxy map scaffold and design pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ Categories (omit a category if it has no entries):
   Full implementation lands across three sub-issues of #91. (Refs #91)
 
 ### Bug Fixes
+- Galaxy map scaffold now sizes correctly via shared `.galaxy-map` /
+  `.system-map` CSS rules (mirrors `.starmap`); previously the new SVGs
+  fell back to the 300x150 default. Markers in `GalaxyMap` and
+  `SystemMap` are keyboard-focusable with `role="button"`, descriptive
+  `aria-label`s, and Enter/Space activation; `role="img"` removed from
+  the interactive SVGs. `MiniMap` now exposes its name to assistive tech
+  via `<title>` + `aria-labelledby` on the `<svg>` itself. (Refs #91)
 - Replaced `Math.random()` bootstrap calls in `src/engine/rng.ts` and
   `src/engine/game.ts` with `crypto.getRandomValues()`, satisfying the
   determinism policy. The UI and engine no longer call `Math.random`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ Categories (omit a category if it has no entries):
   forward automatically on load. Legacy saves written by v0.1.x are detected
   by the old key and migrated seamlessly — no save lost on upgrade. (#21)
 
+### Internal
+- Galaxy map renderer scaffold. Adds `GalaxyMap`, `SystemMap`, and
+  `MiniMap` SVG components plus a `flags.galaxyMap` feature flag in the
+  Zustand store. The Helm screen renders the new components only when
+  the flag is on; default is off, so existing behaviour is unchanged.
+  Full implementation lands across three sub-issues of #91. (Refs #91)
+
 ### Bug Fixes
 - Replaced `Math.random()` bootstrap calls in `src/engine/rng.ts` and
   `src/engine/game.ts` with `crypto.getRandomValues()`, satisfying the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stellar-reach",
-  "version": "0.1.0-dev.0",
+  "version": "0.2.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stellar-reach",
-      "version": "0.1.0-dev.0",
+      "version": "0.2.0-dev.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/src/data/changelog.generated.json
+++ b/src/data/changelog.generated.json
@@ -1,8 +1,8 @@
 {
   "currentVersion": "0.2.0-dev.0",
-  "build": 22,
+  "build": 23,
   "channel": "development",
-  "generatedAt": "2026-05-02T20:27:32.945Z",
+  "generatedAt": "2026-05-02T20:27:37.236Z",
   "releases": [
     {
       "version": "Unreleased",
@@ -36,6 +36,7 @@
           "id": "bug-fixes",
           "label": "Fixes",
           "entries": [
+            "Galaxy map scaffold now sizes correctly via shared `.galaxy-map` / `.system-map` CSS rules (mirrors `.starmap`); previously the new SVGs fell back to the 300x150 default. Markers in `GalaxyMap` and `SystemMap` are keyboard-focusable with `role=\"button\"`, descriptive `aria-label`s, and Enter/Space activation; `role=\"img\"` removed from the interactive SVGs. `MiniMap` now exposes its name to assistive tech via `<title>` + `aria-labelledby` on the `<svg>` itself. (Refs #91)",
             "Replaced `Math.random()` bootstrap calls in `src/engine/rng.ts` and `src/engine/game.ts` with `crypto.getRandomValues()`, satisfying the determinism policy. The UI and engine no longer call `Math.random` anywhere. (#22)"
           ]
         },

--- a/src/data/changelog.generated.json
+++ b/src/data/changelog.generated.json
@@ -1,8 +1,8 @@
 {
   "currentVersion": "0.2.0-dev.0",
-  "build": 21,
+  "build": 22,
   "channel": "development",
-  "generatedAt": "2026-05-02T19:44:43.621Z",
+  "generatedAt": "2026-05-02T20:27:32.945Z",
   "releases": [
     {
       "version": "Unreleased",
@@ -23,6 +23,13 @@
           "label": "Improvements",
           "entries": [
             "Save files now carry a version envelope (`{ v, state }`) and migrate forward automatically on load. Legacy saves written by v0.1.x are detected by the old key and migrated seamlessly — no save lost on upgrade. (#21)"
+          ]
+        },
+        {
+          "id": "internal",
+          "label": "Internal",
+          "entries": [
+            "Galaxy map renderer scaffold. Adds `GalaxyMap`, `SystemMap`, and `MiniMap` SVG components plus a `flags.galaxyMap` feature flag in the Zustand store. The Helm screen renders the new components only when the flag is on; default is off, so existing behaviour is unchanged. Full implementation lands across three sub-issues of #91. (Refs #91)"
           ]
         },
         {

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -30,7 +30,16 @@ interface AppState {
   game: GameState | null;
   trip: PendingTrip | null;
   lastResolution: ChoiceResolution | null;
+  /**
+   * UI-only feature flags. Off by default. Persisted nowhere; flipped at
+   * runtime via dev tooling or the title screen during scaffold work.
+   */
+  flags: {
+    /** Render the new SVG GalaxyMap / SystemMap / MiniMap (parent #91). */
+    galaxyMap: boolean;
+  };
   setScreen(s: Screen): void;
+  setFlag(name: keyof AppState['flags'], value: boolean): void;
 
   // Lifecycle
   startNewGame(seed?: string, captainName?: string): void;
@@ -61,7 +70,12 @@ export const useGameStore = create<AppState>((set, get) => ({
   game: null,
   trip: null,
   lastResolution: null,
+  flags: {
+    galaxyMap: false,
+  },
   setScreen: (s) => set({ screen: s }),
+  setFlag: (name, value) =>
+    set((s) => ({ flags: { ...s.flags, [name]: value } })),
 
   startNewGame: (seed, captainName) => {
     const g = newGame({ seed, captainName });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -407,6 +407,40 @@ select {
   stroke: var(--accent-cyan);
 }
 
+/*
+ * GalaxyMap / SystemMap share the .starmap sizing contract: full-width,
+ * 1:1 aspect ratio, framed background, SVG fills the container. The
+ * .galaxy-map wrapper additionally hosts the absolutely-positioned reset
+ * control as a top-right overlay.
+ */
+.galaxy-map,
+.system-map {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  background:
+    radial-gradient(circle at 30% 30%, rgba(167, 139, 250, 0.08), transparent 60%),
+    radial-gradient(circle at 70% 70%, rgba(34, 211, 238, 0.08), transparent 55%),
+    var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.galaxy-map svg,
+.system-map svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.galaxy-map-reset {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 1;
+}
+
 .modal-backdrop {
   position: fixed;
   inset: 0;

--- a/src/ui/components/GalaxyMap.tsx
+++ b/src/ui/components/GalaxyMap.tsx
@@ -1,0 +1,124 @@
+import { useMemo, useState } from 'react';
+import type { GalaxyState, StarSystem } from '../../engine/types';
+
+// ---------------------------------------------------------------------------
+// GalaxyMap — SVG renderer for the entire galaxy.
+//
+// Status: scaffold. The real implementation is tracked as a sub-issue of
+// parent feature #91. This file establishes the component shape and the
+// viewport math so subsequent passes (full pan/zoom, station markers,
+// route preview) drop into a known surface.
+//
+// Architecture notes (see PR description for parent #91 design pass):
+//   - Galaxy data comes from `state.galaxy` already laid out on a 1000x1000
+//     coordinate space by the seeded generator in `src/engine/galaxy.ts`.
+//   - Pan/zoom is driven by a `viewBox` on the root <svg>; all DOM math is
+//     SVG-native, no canvas, no transform-on-children.
+//   - Pointer interaction will be unified across mouse + touch via
+//     PointerEvent — no separate touch handlers, no UA sniffing.
+//   - The currently-rendered viewBox lives in component state so React
+//     re-renders are cheap (one number tuple) and the renderer remains
+//     deterministic against props.
+// ---------------------------------------------------------------------------
+
+const GALAXY_BOUNDS = 1000;
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 4;
+
+interface Props {
+  galaxy: GalaxyState;
+  /** Id of the system the player currently occupies. */
+  currentSystemId?: string;
+  /** Id of the system the player has currently selected (target). */
+  selectedSystemId?: string;
+  /** Faction colour resolver. Falls back to a neutral line colour. */
+  factionColour?: (system: StarSystem) => string;
+  /** Click / tap handler for a system marker. */
+  onSelectSystem?: (system: StarSystem) => void;
+}
+
+interface ViewBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+const INITIAL_VIEW: ViewBox = { x: 0, y: 0, w: GALAXY_BOUNDS, h: GALAXY_BOUNDS };
+
+function clampZoom(z: number): number {
+  return Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, z));
+}
+
+export function GalaxyMap({
+  galaxy,
+  currentSystemId,
+  selectedSystemId,
+  factionColour,
+  onSelectSystem,
+}: Props) {
+  const [view, setView] = useState<ViewBox>(INITIAL_VIEW);
+
+  const viewBoxStr = `${view.x} ${view.y} ${view.w} ${view.h}`;
+
+  const systems = galaxy.systems;
+  const colourOf = useMemo(
+    () => (sys: StarSystem) => (factionColour ? factionColour(sys) : 'var(--line-2)'),
+    [factionColour],
+  );
+
+  // Reset is exposed via a button overlay so the player can recover from a
+  // disorienting zoom. Pan/zoom gestures themselves arrive in a follow-up
+  // sub-task; the scaffold leaves the view static at the default bounds.
+  function resetView() {
+    setView(INITIAL_VIEW);
+  }
+
+  // Reserved for the pan/zoom sub-task; suppresses unused-warning for
+  // clampZoom while the scaffold is in place.
+  void clampZoom;
+
+  return (
+    <div className="galaxy-map" data-scaffold="true">
+      <svg viewBox={viewBoxStr} role="img" aria-label="Galaxy map">
+        {systems.map((sys) => {
+          const isCurrent = sys.id === currentSystemId;
+          const isSelected = sys.id === selectedSystemId;
+          return (
+            <g key={sys.id}>
+              <circle
+                cx={sys.x}
+                cy={sys.y}
+                r={isCurrent ? 14 : 10}
+                fill={colourOf(sys)}
+                fillOpacity={0.25}
+                stroke={isCurrent ? 'var(--accent-ok)' : isSelected ? 'var(--accent-amber)' : colourOf(sys)}
+                strokeWidth={isCurrent ? 2.5 : 1.5}
+                onClick={() => onSelectSystem?.(sys)}
+                style={{ cursor: onSelectSystem ? 'pointer' : 'default' }}
+              />
+              <text
+                x={sys.x}
+                y={sys.y - 18}
+                textAnchor="middle"
+                fontSize={18}
+                fill="var(--fg-1)"
+                style={{ pointerEvents: 'none' }}
+              >
+                {sys.name}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      <button
+        type="button"
+        className="muted galaxy-map-reset"
+        onClick={resetView}
+        aria-label="Reset map view"
+      >
+        Reset View
+      </button>
+    </div>
+  );
+}

--- a/src/ui/components/GalaxyMap.tsx
+++ b/src/ui/components/GalaxyMap.tsx
@@ -22,8 +22,9 @@ import type { GalaxyState, StarSystem } from '../../engine/types';
 // ---------------------------------------------------------------------------
 
 const GALAXY_BOUNDS = 1000;
-const MIN_ZOOM = 0.5;
-const MAX_ZOOM = 4;
+// sol: zoom bounds (MIN_ZOOM / MAX_ZOOM) and the matching `clampZoom`
+// helper land with the pan/zoom gesture handlers in #94 — intentionally
+// omitted from the scaffold to keep the surface lint-clean.
 
 interface Props {
   galaxy: GalaxyState;
@@ -46,10 +47,6 @@ interface ViewBox {
 
 const INITIAL_VIEW: ViewBox = { x: 0, y: 0, w: GALAXY_BOUNDS, h: GALAXY_BOUNDS };
 
-function clampZoom(z: number): number {
-  return Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, z));
-}
-
 export function GalaxyMap({
   galaxy,
   currentSystemId,
@@ -67,23 +64,26 @@ export function GalaxyMap({
     [factionColour],
   );
 
-  // Reset is exposed via a button overlay so the player can recover from a
-  // disorienting zoom. Pan/zoom gestures themselves arrive in a follow-up
-  // sub-task; the scaffold leaves the view static at the default bounds.
+  // Reset is exposed via an absolutely-positioned overlay button (see
+  // `.galaxy-map-reset` in global.css) so the player can recover from a
+  // disorienting zoom without scrolling. Pan/zoom gestures themselves
+  // arrive in a follow-up sub-task; the scaffold leaves the view static
+  // at the default bounds.
   function resetView() {
     setView(INITIAL_VIEW);
   }
 
-  // Reserved for the pan/zoom sub-task; suppresses unused-warning for
-  // clampZoom while the scaffold is in place.
-  void clampZoom;
+  function activate(sys: StarSystem) {
+    onSelectSystem?.(sys);
+  }
 
   return (
     <div className="galaxy-map" data-scaffold="true">
-      <svg viewBox={viewBoxStr} role="img" aria-label="Galaxy map">
+      <svg viewBox={viewBoxStr} aria-label="Galaxy map">
         {systems.map((sys) => {
           const isCurrent = sys.id === currentSystemId;
           const isSelected = sys.id === selectedSystemId;
+          const interactive = !!onSelectSystem;
           return (
             <g key={sys.id}>
               <circle
@@ -94,9 +94,21 @@ export function GalaxyMap({
                 fillOpacity={0.25}
                 stroke={isCurrent ? 'var(--accent-ok)' : isSelected ? 'var(--accent-amber)' : colourOf(sys)}
                 strokeWidth={isCurrent ? 2.5 : 1.5}
-                onClick={() => onSelectSystem?.(sys)}
-                style={{ cursor: onSelectSystem ? 'pointer' : 'default' }}
-              />
+                onClick={() => activate(sys)}
+                onKeyDown={(e) => {
+                  if (!interactive) return;
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    activate(sys);
+                  }
+                }}
+                tabIndex={interactive ? 0 : -1}
+                role={interactive ? 'button' : undefined}
+                aria-label={`Select system ${sys.name}`}
+                style={{ cursor: interactive ? 'pointer' : 'default' }}
+              >
+                <title>{sys.name}</title>
+              </circle>
               <text
                 x={sys.x}
                 y={sys.y - 18}

--- a/src/ui/components/MiniMap.tsx
+++ b/src/ui/components/MiniMap.tsx
@@ -13,9 +13,11 @@ interface Props {
 }
 
 export function MiniMap({ galaxy, currentSystemId }: Props) {
+  const titleId = 'minimap-title';
   return (
-    <div className="minimap" aria-label="Galaxy mini-map">
-      <svg viewBox="0 0 1000 1000" role="img">
+    <div className="minimap">
+      <svg viewBox="0 0 1000 1000" role="img" aria-labelledby={titleId}>
+        <title id={titleId}>Galaxy mini-map</title>
         {galaxy.systems.map((sys) => {
           const isCurrent = sys.id === currentSystemId;
           return (

--- a/src/ui/components/MiniMap.tsx
+++ b/src/ui/components/MiniMap.tsx
@@ -1,0 +1,37 @@
+import type { GalaxyState } from '../../engine/types';
+
+// ---------------------------------------------------------------------------
+// MiniMap — desktop-only compact galaxy preview for the right rail.
+//
+// Status: scaffold. The full Helm integration (click-to-jump-viewport,
+// coordinated highlighting) is tracked as a sub-issue of parent #91.
+// ---------------------------------------------------------------------------
+
+interface Props {
+  galaxy: GalaxyState;
+  currentSystemId?: string;
+}
+
+export function MiniMap({ galaxy, currentSystemId }: Props) {
+  return (
+    <div className="minimap" aria-label="Galaxy mini-map">
+      <svg viewBox="0 0 1000 1000" role="img">
+        {galaxy.systems.map((sys) => {
+          const isCurrent = sys.id === currentSystemId;
+          return (
+            <circle
+              key={sys.id}
+              cx={sys.x}
+              cy={sys.y}
+              r={isCurrent ? 22 : 14}
+              fill={isCurrent ? 'var(--accent-ok)' : 'var(--line-2)'}
+              fillOpacity={isCurrent ? 0.6 : 0.45}
+              stroke={isCurrent ? 'var(--accent-ok)' : 'transparent'}
+              strokeWidth={2}
+            />
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/src/ui/components/SystemMap.tsx
+++ b/src/ui/components/SystemMap.tsx
@@ -1,0 +1,113 @@
+import type { StarSystem, Station } from '../../engine/types';
+
+// ---------------------------------------------------------------------------
+// SystemMap — SVG renderer for a single star system.
+//
+// Status: scaffold. Tracked as a sub-issue of parent feature #91.
+//
+// Notes:
+//   - Stations carry `(x, y)` already laid out by the galaxy generator on a
+//     0..500 system-local coordinate space.
+//   - Station kinds will resolve to distinct angular SVG glyphs in the full
+//     pass; the scaffold uses simple shape primitives so the integration
+//     point is stable.
+// ---------------------------------------------------------------------------
+
+const SYSTEM_BOUNDS = 500;
+
+interface Props {
+  system: StarSystem;
+  /** Id of the station the player currently occupies. */
+  currentStationId?: string;
+  /** Id of the station the player has selected as the next destination. */
+  selectedStationId?: string;
+  /** Click / tap handler for a station marker. */
+  onSelectStation?: (station: Station) => void;
+}
+
+function glyphForStationKind(station: Station): JSX.Element {
+  // Distinct shape per station kind. Stays inside a 12px bounding box so all
+  // kinds share visual weight on the system map.
+  const cx = station.x;
+  const cy = station.y;
+  switch (station.kind) {
+    case 'Trade Hub':
+    case 'Industrial':
+    case 'Refinery':
+      return <rect x={cx - 6} y={cy - 6} width={12} height={12} />;
+    case 'Military':
+      return (
+        <polygon
+          points={`${cx},${cy - 7} ${cx + 7},${cy + 5} ${cx - 7},${cy + 5}`}
+        />
+      );
+    case 'Black Market':
+      return (
+        <polygon
+          points={`${cx - 6},${cy - 6} ${cx + 6},${cy - 6} ${cx + 6},${cy + 6} ${cx - 6},${cy + 6}`}
+          transform={`rotate(45 ${cx} ${cy})`}
+        />
+      );
+    case 'Pleasure Resort':
+    case 'Agricultural':
+      return <circle cx={cx} cy={cy} r={6} />;
+    default:
+      return <rect x={cx - 5} y={cy - 5} width={10} height={10} />;
+  }
+}
+
+export function SystemMap({
+  system,
+  currentStationId,
+  selectedStationId,
+  onSelectStation,
+}: Props) {
+  return (
+    <div className="system-map" data-scaffold="true">
+      <svg
+        viewBox={`0 0 ${SYSTEM_BOUNDS} ${SYSTEM_BOUNDS}`}
+        role="img"
+        aria-label={`${system.name} system map`}
+      >
+        {/* Central star — decorative anchor point. */}
+        <circle
+          cx={SYSTEM_BOUNDS / 2}
+          cy={SYSTEM_BOUNDS / 2}
+          r={14}
+          fill="var(--accent-amber)"
+          fillOpacity={0.25}
+          stroke="var(--accent-amber)"
+          strokeWidth={1}
+        />
+
+        {system.stations.map((station) => {
+          const isCurrent = station.id === currentStationId;
+          const isSelected = station.id === selectedStationId;
+          return (
+            <g
+              key={station.id}
+              onClick={() => onSelectStation?.(station)}
+              style={{ cursor: onSelectStation ? 'pointer' : 'default' }}
+              fill={isCurrent ? 'var(--accent-ok)' : isSelected ? 'var(--accent-amber)' : 'var(--bg-3)'}
+              stroke={isCurrent ? 'var(--accent-ok)' : isSelected ? 'var(--accent-amber)' : 'var(--line-2)'}
+              strokeWidth={isCurrent ? 2 : 1}
+            >
+              {glyphForStationKind(station)}
+              <text
+                x={station.x}
+                y={station.y - 12}
+                textAnchor="middle"
+                fontSize={11}
+                fill="var(--fg-1)"
+                stroke="none"
+                style={{ pointerEvents: 'none' }}
+              >
+                {station.name}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/src/ui/components/SystemMap.tsx
+++ b/src/ui/components/SystemMap.tsx
@@ -62,13 +62,14 @@ export function SystemMap({
   selectedStationId,
   onSelectStation,
 }: Props) {
+  const titleId = `system-map-title-${system.id}`;
   return (
     <div className="system-map" data-scaffold="true">
       <svg
         viewBox={`0 0 ${SYSTEM_BOUNDS} ${SYSTEM_BOUNDS}`}
-        role="img"
-        aria-label={`${system.name} system map`}
+        aria-labelledby={titleId}
       >
+        <title id={titleId}>{`${system.name} system map`}</title>
         {/* Central star — decorative anchor point. */}
         <circle
           cx={SYSTEM_BOUNDS / 2}
@@ -83,15 +84,27 @@ export function SystemMap({
         {system.stations.map((station) => {
           const isCurrent = station.id === currentStationId;
           const isSelected = station.id === selectedStationId;
+          const interactive = !!onSelectStation;
           return (
             <g
               key={station.id}
               onClick={() => onSelectStation?.(station)}
-              style={{ cursor: onSelectStation ? 'pointer' : 'default' }}
+              onKeyDown={(e) => {
+                if (!interactive) return;
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onSelectStation?.(station);
+                }
+              }}
+              tabIndex={interactive ? 0 : -1}
+              role={interactive ? 'button' : undefined}
+              aria-label={`Select station ${station.name} (${station.kind})`}
+              style={{ cursor: interactive ? 'pointer' : 'default' }}
               fill={isCurrent ? 'var(--accent-ok)' : isSelected ? 'var(--accent-amber)' : 'var(--bg-3)'}
               stroke={isCurrent ? 'var(--accent-ok)' : isSelected ? 'var(--accent-amber)' : 'var(--line-2)'}
               strokeWidth={isCurrent ? 2 : 1}
             >
+              <title>{`${station.name} — ${station.kind}`}</title>
               {glyphForStationKind(station)}
               <text
                 x={station.x}

--- a/src/ui/screens/HelmScreen.tsx
+++ b/src/ui/screens/HelmScreen.tsx
@@ -4,6 +4,8 @@ import { allStations, currentStation, currentSystem } from '../../engine/game';
 import { estimateRoute } from '../../engine/game';
 import { RACES_BY_ID } from '../../data/races';
 import { GOODS_BY_ID } from '../../data/goods';
+import { GalaxyMap } from '../components/GalaxyMap';
+import { SystemMap } from '../components/SystemMap';
 
 type SafetyChoice = 'safe' | 'fast';
 
@@ -15,6 +17,7 @@ const MAX_TRADE_HINTS = 4;
 export function HelmScreen() {
   const game = useGameStore((s) => s.game)!;
   const beginTrip = useGameStore((s) => s.beginTrip);
+  const galaxyMapEnabled = useGameStore((s) => s.flags.galaxyMap);
 
   const [selected, setSelected] = useState<string | null>(null);
   const [safety, setSafety] = useState<SafetyChoice>('safe');
@@ -66,7 +69,27 @@ export function HelmScreen() {
     <div>
       <div className="card">
         <h3>Star Map</h3>
-        <div className="starmap">
+        {galaxyMapEnabled ? (
+          <>
+            <GalaxyMap
+              galaxy={game.galaxy}
+              currentSystemId={system?.id}
+              selectedSystemId={targetSys?.id}
+              onSelectSystem={(sys) => setSelected(sys.stations[0]?.id ?? null)}
+            />
+            {targetSys && (
+              <div style={{ marginTop: 12 }}>
+                <SystemMap
+                  system={targetSys}
+                  currentStationId={station?.id}
+                  selectedStationId={selected ?? undefined}
+                  onSelectStation={(st) => setSelected(st.id)}
+                />
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="starmap">
           <svg viewBox="0 0 1000 1000">
             {game.galaxy.systems.map((sys) => {
               const isCurrent = sys.id === system?.id;
@@ -101,6 +124,7 @@ export function HelmScreen() {
             })}
           </svg>
         </div>
+        )}
       </div>
 
       <div className="card">


### PR DESCRIPTION
Refs #91 (parent stays open until sub-issues #94, #95, #96 land)

## Design pass

### Goals

Visual galaxy + per-system map that scales from mobile portrait to 16:9
desktop, driven by the existing seeded galaxy in `src/engine/galaxy.ts`.
Replaces the placeholder text-list Helm view incrementally.

### Architecture

- **SVG, not canvas.** `viewBox`-driven scaling means crisp text at every
  zoom level, accessible markup, and zero raster blurring on Retina /
  HiDPI screens. Pan/zoom mutates the `viewBox` tuple on the root `<svg>`,
  not transforms on children — keeps hit-testing trivial.
- **Coordinate spaces.** Galaxy: 1000×1000, already laid out by the
  generator across four concentric rings. System: 0..500 with the central
  star at 250,250. Stations carry per-system `(x, y)` already.
- **Layout algorithm.** Existing — the seeded `generateGalaxy` distributes
  systems on rings via `rng.range`, deterministic per seed. No new
  randomness needed; the renderer is a pure projection of that data.
- **Pan / zoom math.** `viewBox = (x, y, w, h)`. Pan adds `(dx, dy)` to
  `(x, y)`. Zoom multiplies `(w, h)` and recentres so the cursor / pinch
  midpoint stays under the same world coordinate. Min 0.5x, max 4x.
- **Interaction.** Unified `PointerEvent` for mouse + touch + pen. Wheel
  + Ctrl-wheel for desktop, two-finger pinch for touch, drag-pan for
  both. Keyboard: arrows pan, `+` / `-` zoom, `0` resets. `prefers-
  reduced-motion` short-circuits any easing on view transitions.
- **Helm integration.** New components live behind a
  `flags.galaxyMap` boolean in the Zustand store, default `false`. The
  legacy starmap stays as the off-flag fallback so this PR is a pure
  scaffold land. The desktop right rail will host the `MiniMap`; that
  wiring lands with sub-task #96 once #92 (right rail) merges to
  development.

### File layout

- `src/ui/components/GalaxyMap.tsx` — galaxy view scaffold.
- `src/ui/components/SystemMap.tsx` — single-system view scaffold with
  per-`StationKind` SVG glyphs.
- `src/ui/components/MiniMap.tsx` — compact static preview for the
  right rail.

## Sub-issues

Three sub-issues are linked to #91 via REST `sub_issue_id`:

- #94 — galaxy(renderer): SVG galaxy view with pan/zoom
- #95 — galaxy(renderer): SVG system view with station markers
- #96 — galaxy(ui): mini-map and Helm integration

The parent issue body now carries a tasklist of those three.

## Verification

`npm run typecheck`, `npm run lint`, and `npm run build` all green with
the feature flag off (default). Existing Helm behaviour unchanged.

## Out of scope for this PR

- Pan/zoom gesture wiring (sub-issue #94).
- Station marker styling pass (sub-issue #95).
- Mini-map and Helm canonicalisation (sub-issue #96).
- Combat or war-front overlays (parent issue's own out-of-scope).
